### PR TITLE
Set the JsonProperty correctly for card type

### DIFF
--- a/Beanstream/Domain/Card.cs
+++ b/Beanstream/Domain/Card.cs
@@ -79,7 +79,7 @@ namespace Beanstream.Api.SDK.Domain
 		/// Identifies VI (visa) MA (mastercard) etc.
 		/// You do not have to set this value, the API will set it for you based on the BIN of the card number.
 		/// </summary>
-		[JsonProperty(PropertyName = "type")]
+		[JsonProperty(PropertyName = "card_type")]
 		public string Type { get; set; }
 
 		/// <summary>


### PR DESCRIPTION
Card.Type was not being deserialized properly because the JsonProperty did not match the shape of the response from the server.
